### PR TITLE
Modify type of glue-catalog-table partition_keys variable

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -9,3 +9,22 @@ stage = "test"
 name = "glue"
 
 glue_version = "2.0"
+
+glue_catalog_table_partition_keys = {
+  "test" = {
+    name    = "test"
+    comment = "test"
+    type    = "string"
+  }
+  "test2" = {
+    name = "test2"
+    type = "string"
+  }
+  "test3" = {
+    name = "test3"
+  }
+  "test4" = {
+    name    = "test4"
+    comment = "test4"
+  }
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -31,6 +31,8 @@ module "glue_catalog_table" {
     location = local.data_source
   }
 
+  partition_keys = var.glue_catalog_table_partition_keys
+
   context = module.this.context
 }
 

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -8,3 +8,9 @@ variable "glue_version" {
   description = "The version of glue to use"
   default     = "2.0"
 }
+
+variable "glue_catalog_table_partition_keys" {
+  type        = map(any)
+  description = "Configuration block of columns by which the table is partitioned. Only primitive types are supported as partition keys."
+  default     = {}
+}

--- a/modules/glue-catalog-table/main.tf
+++ b/modules/glue-catalog-table/main.tf
@@ -27,12 +27,12 @@ resource "aws_glue_catalog_table" "this" {
   }
 
   dynamic "partition_keys" {
-    for_each = var.partition_keys != null ? [true] : []
+    for_each = var.partition_keys
 
     content {
-      name    = var.partition_keys.name
-      comment = try(var.partition_keys.comment, null)
-      type    = try(var.partition_keys.type, null)
+      name    = partition_keys.value.name
+      comment = try(partition_keys.value.comment, null)
+      type    = try(partition_keys.value.type, null)
     }
   }
 

--- a/modules/glue-catalog-table/variables.tf
+++ b/modules/glue-catalog-table/variables.tf
@@ -49,9 +49,9 @@ variable "partition_keys" {
   #    type    = string
   #  })
   # Using `type = map(string)` since some of the the fields are optional and we don't want to force the caller to specify all of them and set to `null` those not used
-  type        = map(string)
+  type        = map(any)
   description = "Configuration block of columns by which the table is partitioned. Only primitive types are supported as partition keys."
-  default     = null
+  default     = {}
 }
 
 variable "retention" {


### PR DESCRIPTION
## what

- Modify glue-catalog-table partition_keys variable to allow specification of multiple partition keys
- Add example var value to fixtures to include testing of this var

## why

- Existing code appeared to support a single partition key, e.g.
  ```
    partition_keys = {
      name    = "test"
      comment = "test"
      type    = "string"
    }
  ```

## references

- closes #7