### PR TITLE
Added create_native_delta_table to dynamodb_target, for glue crawler module

### DIFF
--- a/modules/glue-crawler/main.tf
+++ b/modules/glue-crawler/main.tf
@@ -29,9 +29,10 @@ resource "aws_glue_crawler" "this" {
     for_each = var.delta_target != null ? var.delta_target : []
 
     content {
-      connection_name = delta_target.value.connection_name
-      delta_tables    = delta_target.value.delta_tables
-      write_manifest  = delta_target.value.write_manifest
+      connection_name           = delta_target.value.connection_name
+      create_native_delta_table = delta_target.value.create_native_delta_table
+      delta_tables              = delta_target.value.delta_tables
+      write_manifest            = delta_target.value.write_manifest
     }
   }
 

--- a/modules/glue-crawler/variables.tf
+++ b/modules/glue-crawler/variables.tf
@@ -104,9 +104,10 @@ variable "catalog_target" {
 
 variable "delta_target" {
   type = list(object({
-    connection_name = string
-    delta_tables    = list(string)
-    write_manifest  = bool
+    connection_name           = string
+    create_native_delta_table = bool
+    delta_tables              = list(string)
+    write_manifest            = bool
   }))
   description = "List of nested Delta target arguments."
   default     = null


### PR DESCRIPTION

## what

* Added support for `create_native_delta_table` in `delta_target` block inside `main.tf`.
* Updated the `delta_target` variable definition in `variables.tf` to include `create_native_delta_table` as a `bool` field.

## why

* Enables AWS Glue Crawlers to create **native Delta tables**, which allows better integration with query engines like Athena that can directly read Delta Lake transaction logs.
* Brings the module in line with [[AWS Glue Crawler specifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_crawler#create_native_delta_table-1)](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_crawler#create_native_delta_table-1).

#### Changes

* [x] Code updated to support new argument in `main.tf`
* [x] Variable schema extended in `variables.tf`

## references

* **Closes** [[#37](https://github.com/cloudposse/terraform-aws-glue/issues/37)](https://github.com/cloudposse/terraform-aws-glue/issues/37)
* **Docs**: [https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue\_crawler#create\_native\_delta\_table-1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_crawler#create_native_delta_table-1)